### PR TITLE
Add documentation entry in podfile that links to html preview of latest version

### DIFF
--- a/Capable.podspec
+++ b/Capable.podspec
@@ -11,6 +11,7 @@ Capable lets you easily keep track of accessibility settings used by your app us
   s.license = { :type => 'MIT', :file => 'LICENSE' }
   s.author = { 'Christoph Wendt' => 'christoph.wendt@me.com' }
   s.source = { :git => 'https://github.com/chrs1885/Capable.git', :tag => s.version }
+  s.documentation_url = 'http://htmlpreview.github.io/?https://github.com/chrs1885/Capable/blob/0.4.0/Documentation/index.html'
   s.swift_version = '4.1'
   s.source_files = 'Source/**/*.swift'
 


### PR DESCRIPTION
## Issue information
When visiting the CocoaPods page of the Capable framework, clicking the documentation link displays an error page (404).

## Goal
Display the generated jazzy docs as rendered html for the specific pod version.

## Implementation
Use preview service of github and link to the docs path for the specific tag.

## Testing
Wait for the 0.5.0 release, visit the CocoaPods page of Capable, and click the documentation link.