### PR TITLE
Fix SwiftUI naming collisions by renaming typealias names

### DIFF
--- a/Example/Tests/Colors/ColorWcagTests.swift
+++ b/Example/Tests/Colors/ColorWcagTests.swift
@@ -22,8 +22,8 @@
 #elseif os(OSX)
 
     import AppKit
-    public typealias Color = NSColor
-    public typealias Font = NSFont
+    public typealias ColorType = NSColor
+    public typealias FontType = NSFont
 
     struct Colors {
         static let white = NSColor(white: 1.0, alpha: 1.0)
@@ -45,9 +45,9 @@ import Quick
 class ColorWcagTests: QuickSpec {
     override func spec() {
         struct Fonts {
-            static let smallFont = Font.systemFont(ofSize: 14.0)
-            static let smallBoldFont = Font.boldSystemFont(ofSize: 14.0)
-            static let largeFont = Font.systemFont(ofSize: 18.0)
+            static let smallFont = FontType.systemFont(ofSize: 14.0)
+            static let smallBoldFont = FontType.boldSystemFont(ofSize: 14.0)
+            static let largeFont = FontType.systemFont(ofSize: 18.0)
         }
 
         describe("The UIColor/NSColor class") {
@@ -111,19 +111,19 @@ class ColorWcagTests: QuickSpec {
             context("when calling getContrastRatio") {
                 context("by passing in the same color twice") {
                     it("returns the minimum contrast ratio of 1.0") {
-                        expect(Color.getContrastRatio(forTextColor: Colors.white, onBackgroundColor: Colors.white)).to(equal(1.0))
+                        expect(ColorType.getContrastRatio(forTextColor: Colors.white, onBackgroundColor: Colors.white)).to(equal(1.0))
                     }
                 }
 
                 context("by passing in white and black") {
                     it("returns the maximum contrast ratio of 21.0") {
-                        expect(Color.getContrastRatio(forTextColor: Colors.white, onBackgroundColor: Colors.black)).to(equal(21.0))
+                        expect(ColorType.getContrastRatio(forTextColor: Colors.white, onBackgroundColor: Colors.black)).to(equal(21.0))
                     }
                 }
 
                 context("by passing in green and orange color") {
                     it("returns a contrast ratio of 2.31") {
-                        let actualContrastRatio = Color.getContrastRatio(forTextColor: Colors.colorWithContrastRatio3, onBackgroundColor: Colors.colorWithContrastRatio7)!
+                        let actualContrastRatio = ColorType.getContrastRatio(forTextColor: Colors.colorWithContrastRatio3, onBackgroundColor: Colors.colorWithContrastRatio7)!
                         let rounded = floor(actualContrastRatio * 100) / 100
 
                         expect(rounded).to(equal(2.3))
@@ -132,7 +132,7 @@ class ColorWcagTests: QuickSpec {
 
                 context("by passing in semi transparent color and white") {
                     it("returns a contrast ratio of 4.51") {
-                        let actualContrastRatio = Color.getContrastRatio(forTextColor: Colors.semiTransparentColor, onBackgroundColor: Colors.white)!
+                        let actualContrastRatio = ColorType.getContrastRatio(forTextColor: Colors.semiTransparentColor, onBackgroundColor: Colors.white)!
                         let rounded = floor(actualContrastRatio * 100) / 100
 
                         expect(rounded).to(equal(4.51))
@@ -143,30 +143,30 @@ class ColorWcagTests: QuickSpec {
             context("when calling getTextColor") {
                 context("by passing in a dark background color") {
                     it("returns white") {
-                        let actual = Color.getTextColor(onBackgroundColor: Colors.black)
+                        let actual = ColorType.getTextColor(onBackgroundColor: Colors.black)
 
-                        expect(actual).to(equal(Color.white))
+                        expect(actual).to(equal(ColorType.white))
                     }
                 }
 
                 context("by passing in a light background color") {
                     it("returns black") {
-                        let actual = Color.getTextColor(onBackgroundColor: Colors.white)
+                        let actual = ColorType.getTextColor(onBackgroundColor: Colors.white)
 
-                        expect(actual).to(equal(Color.black))
+                        expect(actual).to(equal(ColorType.black))
                     }
                 }
 
                 context("by passing in a background color with a medium relative luminance") {
                     it("returns black") {
-                        let actual = Color.getTextColor(onBackgroundColor: Colors.colorWithContrastRatio4_5)
+                        let actual = ColorType.getTextColor(onBackgroundColor: Colors.colorWithContrastRatio4_5)
 
-                        expect(actual).to(equal(Color.black))
+                        expect(actual).to(equal(ColorType.black))
                     }
                 }
 
                 context("by passing a background color and a list of text colors") {
-                    var colors: [Color]?
+                    var colors: [ColorType]?
 
                     beforeEach {
                         colors = [
@@ -178,7 +178,7 @@ class ColorWcagTests: QuickSpec {
 
                     context("by not providing any passing color") {
                         it("returns nil") {
-                            let actual = Color.getTextColor(fromColors: [], withFont: Fonts.smallFont, onBackgroundColor: Colors.white, conformanceLevel: .AA)
+                            let actual = ColorType.getTextColor(fromColors: [], withFont: Fonts.smallFont, onBackgroundColor: Colors.white, conformanceLevel: .AA)
 
                             expect(actual).to(beNil())
                         }
@@ -187,7 +187,7 @@ class ColorWcagTests: QuickSpec {
                     context("when defining conformance level .AA") {
                         context("when using a small font") {
                             it("returns black") {
-                                let actual = Color.getTextColor(fromColors: colors!, withFont: Fonts.smallFont, onBackgroundColor: Colors.white, conformanceLevel: .AA)
+                                let actual = ColorType.getTextColor(fromColors: colors!, withFont: Fonts.smallFont, onBackgroundColor: Colors.white, conformanceLevel: .AA)
 
                                 expect(actual).to(equal(Colors.colorWithContrastRatio4_5))
                             }
@@ -195,7 +195,7 @@ class ColorWcagTests: QuickSpec {
 
                         context("when using a small bold font") {
                             it("returns black") {
-                                let actual = Color.getTextColor(fromColors: colors!, withFont: Fonts.smallBoldFont, onBackgroundColor: Colors.white, conformanceLevel: .AA)
+                                let actual = ColorType.getTextColor(fromColors: colors!, withFont: Fonts.smallBoldFont, onBackgroundColor: Colors.white, conformanceLevel: .AA)
 
                                 expect(actual).to(equal(Colors.colorWithContrastRatio3))
                             }
@@ -203,7 +203,7 @@ class ColorWcagTests: QuickSpec {
 
                         context("when using a large font") {
                             it("returns black") {
-                                let actual = Color.getTextColor(fromColors: colors!, withFont: Fonts.largeFont, onBackgroundColor: Colors.white, conformanceLevel: .AA)
+                                let actual = ColorType.getTextColor(fromColors: colors!, withFont: Fonts.largeFont, onBackgroundColor: Colors.white, conformanceLevel: .AA)
 
                                 expect(actual).to(equal(Colors.colorWithContrastRatio3))
                             }
@@ -213,7 +213,7 @@ class ColorWcagTests: QuickSpec {
                     context("when defining conformance level .AAA") {
                         context("when using a small font") {
                             it("returns black") {
-                                let actual = Color.getTextColor(fromColors: colors!, withFont: Fonts.smallFont, onBackgroundColor: Colors.white, conformanceLevel: .AAA)
+                                let actual = ColorType.getTextColor(fromColors: colors!, withFont: Fonts.smallFont, onBackgroundColor: Colors.white, conformanceLevel: .AAA)
 
                                 expect(actual).to(equal(Colors.colorWithContrastRatio7))
                             }
@@ -221,7 +221,7 @@ class ColorWcagTests: QuickSpec {
 
                         context("when using a small bold font") {
                             it("returns black") {
-                                let actual = Color.getTextColor(fromColors: colors!, withFont: Fonts.smallBoldFont, onBackgroundColor: Colors.white, conformanceLevel: .AAA)
+                                let actual = ColorType.getTextColor(fromColors: colors!, withFont: Fonts.smallBoldFont, onBackgroundColor: Colors.white, conformanceLevel: .AAA)
 
                                 expect(actual).to(equal(Colors.colorWithContrastRatio4_5))
                             }
@@ -229,7 +229,7 @@ class ColorWcagTests: QuickSpec {
 
                         context("when using a large font") {
                             it("returns black") {
-                                let actual = Color.getTextColor(fromColors: colors!, withFont: Fonts.largeFont, onBackgroundColor: Colors.white, conformanceLevel: .AAA)
+                                let actual = ColorType.getTextColor(fromColors: colors!, withFont: Fonts.largeFont, onBackgroundColor: Colors.white, conformanceLevel: .AAA)
 
                                 expect(actual).to(equal(Colors.colorWithContrastRatio4_5))
                             }
@@ -241,37 +241,37 @@ class ColorWcagTests: QuickSpec {
 
                     context("by passing in a dark background image") {
                         it("returns white") {
-                            let backgroundImage = Image.mock(withColor: Colors.black)
-                            let actual = Color.getTextColor(onBackgroundImage: backgroundImage)
+                            let backgroundImage = ImageType.mock(withColor: Colors.black)
+                            let actual = ColorType.getTextColor(onBackgroundImage: backgroundImage)
 
-                            expect(actual).to(equal(Color.white))
+                            expect(actual).to(equal(ColorType.white))
                         }
                     }
 
                     context("by passing in a light background image") {
                         it("returns black") {
-                            let backgroundImage = Image.mock(withColor: Colors.white)
-                            let actual = Color.getTextColor(onBackgroundImage: backgroundImage)
+                            let backgroundImage = ImageType.mock(withColor: Colors.white)
+                            let actual = ColorType.getTextColor(onBackgroundImage: backgroundImage)
 
-                            expect(actual).to(equal(Color.black))
+                            expect(actual).to(equal(ColorType.black))
                         }
                     }
 
                     context("by passing in a background image with a medium relative luminance") {
                         it("returns black") {
-                            let backgroundImage = Image.mock(withColor: Colors.colorWithContrastRatio4_5)
-                            let actual = Color.getTextColor(onBackgroundImage: backgroundImage)
+                            let backgroundImage = ImageType.mock(withColor: Colors.colorWithContrastRatio4_5)
+                            let actual = ColorType.getTextColor(onBackgroundImage: backgroundImage)
 
-                            expect(actual).to(equal(Color.black))
+                            expect(actual).to(equal(ColorType.black))
                         }
                     }
 
                     context("by passing a background image and a list of text colors") {
-                        var colors: [Color]!
-                        var backgroundImage: Image!
+                        var colors: [ColorType]!
+                        var backgroundImage: ImageType!
 
                         beforeEach {
-                            backgroundImage = Image.mock(withColor: Colors.white)
+                            backgroundImage = ImageType.mock(withColor: Colors.white)
                             colors = [
                                 Colors.colorWithContrastRatio3,
                                 Colors.colorWithContrastRatio4_5,
@@ -281,7 +281,7 @@ class ColorWcagTests: QuickSpec {
 
                         context("by not providing any passing color") {
                             it("returns nil") {
-                                let actual = Color.getTextColor(fromColors: [], withFont: Fonts.smallFont, onBackgroundImage: backgroundImage, conformanceLevel: .AA)
+                                let actual = ColorType.getTextColor(fromColors: [], withFont: Fonts.smallFont, onBackgroundImage: backgroundImage, conformanceLevel: .AA)
 
                                 expect(actual).to(beNil())
                             }
@@ -290,7 +290,7 @@ class ColorWcagTests: QuickSpec {
                         context("when defining conformance level .AA") {
                             context("when using a small font") {
                                 it("returns a color of conformance level 4.5") {
-                                    let actual = Color.getTextColor(fromColors: colors, withFont: Fonts.smallFont, onBackgroundImage: backgroundImage, conformanceLevel: .AA)
+                                    let actual = ColorType.getTextColor(fromColors: colors, withFont: Fonts.smallFont, onBackgroundImage: backgroundImage, conformanceLevel: .AA)
 
                                     expect(actual).to(equal(Colors.colorWithContrastRatio4_5))
                                 }
@@ -298,7 +298,7 @@ class ColorWcagTests: QuickSpec {
 
                             context("when using a small bold font") {
                                 it("returns a color of conformance level 3") {
-                                    let actual = Color.getTextColor(fromColors: colors, withFont: Fonts.smallBoldFont, onBackgroundImage: backgroundImage, conformanceLevel: .AA)
+                                    let actual = ColorType.getTextColor(fromColors: colors, withFont: Fonts.smallBoldFont, onBackgroundImage: backgroundImage, conformanceLevel: .AA)
 
                                     expect(actual).to(equal(Colors.colorWithContrastRatio3))
                                 }
@@ -306,7 +306,7 @@ class ColorWcagTests: QuickSpec {
 
                             context("when using a large font") {
                                 it("returns a color of conformance level 3") {
-                                    let actual = Color.getTextColor(fromColors: colors, withFont: Fonts.largeFont, onBackgroundImage: backgroundImage, conformanceLevel: .AA)
+                                    let actual = ColorType.getTextColor(fromColors: colors, withFont: Fonts.largeFont, onBackgroundImage: backgroundImage, conformanceLevel: .AA)
 
                                     expect(actual).to(equal(Colors.colorWithContrastRatio3))
                                 }
@@ -316,7 +316,7 @@ class ColorWcagTests: QuickSpec {
                         context("when defining conformance level .AAA") {
                             context("when using a small font") {
                                 it("returns a color of conformance level 7") {
-                                    let actual = Color.getTextColor(fromColors: colors, withFont: Fonts.smallFont, onBackgroundImage: backgroundImage, conformanceLevel: .AAA)
+                                    let actual = ColorType.getTextColor(fromColors: colors, withFont: Fonts.smallFont, onBackgroundImage: backgroundImage, conformanceLevel: .AAA)
 
                                     expect(actual).to(equal(Colors.colorWithContrastRatio7))
                                 }
@@ -324,7 +324,7 @@ class ColorWcagTests: QuickSpec {
 
                             context("when using a small bold font") {
                                 it("returns a color of conformance level 4.5") {
-                                    let actual = Color.getTextColor(fromColors: colors, withFont: Fonts.smallBoldFont, onBackgroundImage: backgroundImage, conformanceLevel: .AAA)
+                                    let actual = ColorType.getTextColor(fromColors: colors, withFont: Fonts.smallBoldFont, onBackgroundImage: backgroundImage, conformanceLevel: .AAA)
 
                                     expect(actual).to(equal(Colors.colorWithContrastRatio4_5))
                                 }
@@ -332,7 +332,7 @@ class ColorWcagTests: QuickSpec {
 
                             context("when using a large font") {
                                 it("returns a color of conformance level 4.5") {
-                                    let actual = Color.getTextColor(fromColors: colors, withFont: Fonts.largeFont, onBackgroundImage: backgroundImage, conformanceLevel: .AAA)
+                                    let actual = ColorType.getTextColor(fromColors: colors, withFont: Fonts.largeFont, onBackgroundImage: backgroundImage, conformanceLevel: .AAA)
 
                                     expect(actual).to(equal(Colors.colorWithContrastRatio4_5))
                                 }
@@ -346,31 +346,31 @@ class ColorWcagTests: QuickSpec {
             context("when calling getBackgroundColor") {
                 context("by passing in a dark text color") {
                     it("returns white") {
-                        let actual = Color.getBackgroundColor(forTextColor: Colors.black)
+                        let actual = ColorType.getBackgroundColor(forTextColor: Colors.black)
 
-                        expect(actual).to(equal(Color.white))
+                        expect(actual).to(equal(ColorType.white))
                     }
                 }
 
                 context("by passing in a light text color") {
                     it("returns black") {
-                        let actual = Color.getBackgroundColor(forTextColor: Colors.white)
+                        let actual = ColorType.getBackgroundColor(forTextColor: Colors.white)
 
-                        expect(actual).to(equal(Color.black))
+                        expect(actual).to(equal(ColorType.black))
                     }
                 }
 
                 context("by passing in a text color with a medium relative luminance") {
                     it("returns black") {
-                        let actual = Color.getBackgroundColor(forTextColor: Colors.colorWithContrastRatio4_5)
+                        let actual = ColorType.getBackgroundColor(forTextColor: Colors.colorWithContrastRatio4_5)
 
-                        expect(actual).to(equal(Color.black))
+                        expect(actual).to(equal(ColorType.black))
                     }
                 }
             }
 
             context("when calling getBackgroundColor with a list of colors") {
-                var colors: [Color]?
+                var colors: [ColorType]?
 
                 beforeEach {
                     colors = [
@@ -382,7 +382,7 @@ class ColorWcagTests: QuickSpec {
 
                 context("by not providing any passing color") {
                     it("returns nil") {
-                        let actual = Color.getBackgroundColor(fromColors: [], forTextColor: Colors.white, withFont: Fonts.smallFont, conformanceLevel: .AA)
+                        let actual = ColorType.getBackgroundColor(fromColors: [], forTextColor: Colors.white, withFont: Fonts.smallFont, conformanceLevel: .AA)
 
                         expect(actual).to(beNil())
                     }
@@ -391,7 +391,7 @@ class ColorWcagTests: QuickSpec {
                 context("when defining conformance level .AA") {
                     context("when using a small font") {
                         it("returns a color of conformance level 4.5") {
-                            let actual = Color.getBackgroundColor(fromColors: colors!, forTextColor: Colors.white, withFont: Fonts.smallFont, conformanceLevel: .AA)
+                            let actual = ColorType.getBackgroundColor(fromColors: colors!, forTextColor: Colors.white, withFont: Fonts.smallFont, conformanceLevel: .AA)
 
                             expect(actual).to(equal(Colors.colorWithContrastRatio4_5))
                         }
@@ -399,7 +399,7 @@ class ColorWcagTests: QuickSpec {
 
                     context("when using a small bold font") {
                         it("returns a color of conformance level 3") {
-                            let actual = Color.getBackgroundColor(fromColors: colors!, forTextColor: Colors.white, withFont: Fonts.smallBoldFont, conformanceLevel: .AA)
+                            let actual = ColorType.getBackgroundColor(fromColors: colors!, forTextColor: Colors.white, withFont: Fonts.smallBoldFont, conformanceLevel: .AA)
 
                             expect(actual).to(equal(Colors.colorWithContrastRatio3))
                         }
@@ -407,7 +407,7 @@ class ColorWcagTests: QuickSpec {
 
                     context("when using a large font") {
                         it("returns a color of conformance level 3") {
-                            let actual = Color.getBackgroundColor(fromColors: colors!, forTextColor: Colors.white, withFont: Fonts.largeFont, conformanceLevel: .AA)
+                            let actual = ColorType.getBackgroundColor(fromColors: colors!, forTextColor: Colors.white, withFont: Fonts.largeFont, conformanceLevel: .AA)
 
                             expect(actual).to(equal(Colors.colorWithContrastRatio3))
                         }
@@ -417,7 +417,7 @@ class ColorWcagTests: QuickSpec {
                 context("when defining conformance level .AAA") {
                     context("when using a small font") {
                         it("returns a color of conformance level 7") {
-                            let actual = Color.getBackgroundColor(fromColors: colors!, forTextColor: Colors.white, withFont: Fonts.smallFont, conformanceLevel: .AAA)
+                            let actual = ColorType.getBackgroundColor(fromColors: colors!, forTextColor: Colors.white, withFont: Fonts.smallFont, conformanceLevel: .AAA)
 
                             expect(actual).to(equal(Colors.colorWithContrastRatio7))
                         }
@@ -425,7 +425,7 @@ class ColorWcagTests: QuickSpec {
 
                     context("when using a small bold font") {
                         it("returns a color of conformance level 4.5") {
-                            let actual = Color.getBackgroundColor(fromColors: colors!, forTextColor: Colors.white, withFont: Fonts.smallBoldFont, conformanceLevel: .AAA)
+                            let actual = ColorType.getBackgroundColor(fromColors: colors!, forTextColor: Colors.white, withFont: Fonts.smallBoldFont, conformanceLevel: .AAA)
 
                             expect(actual).to(equal(Colors.colorWithContrastRatio4_5))
                         }
@@ -433,7 +433,7 @@ class ColorWcagTests: QuickSpec {
 
                     context("when using a large font") {
                         it("returns a color of conformance level 4.5") {
-                            let actual = Color.getBackgroundColor(fromColors: colors!, forTextColor: Colors.white, withFont: Fonts.largeFont, conformanceLevel: .AAA)
+                            let actual = ColorType.getBackgroundColor(fromColors: colors!, forTextColor: Colors.white, withFont: Fonts.largeFont, conformanceLevel: .AAA)
 
                             expect(actual).to(equal(Colors.colorWithContrastRatio4_5))
                         }

--- a/Example/Tests/Colors/ImageAreaTests.swift
+++ b/Example/Tests/Colors/ImageAreaTests.swift
@@ -13,7 +13,7 @@ class ImageAreaTests: QuickSpec {
     override func spec() {
         describe("The ImageArea class") {
             var sut: ImageArea!
-            let testImage = Image.mock(withColor: .white, rect: CGRect(x: 0, y: 0, width: 3, height: 3))
+            let testImage = ImageType.mock(withColor: .white, rect: CGRect(x: 0, y: 0, width: 3, height: 3))
 
             context("calling rect()") {
                 var actualRect: CGRect!

--- a/Example/Tests/Colors/ImageAverageColorTests.swift
+++ b/Example/Tests/Colors/ImageAverageColorTests.swift
@@ -12,15 +12,15 @@ import Quick
 class ImageAverageColorTests: QuickSpec {
     override func spec() {
         describe("The UIImage/NSImage class") {
-            var sut: Image!
+            var sut: ImageType!
 
             context("when calling averageColor() for a red image") {
                 beforeEach {
-                    sut = Image.mock(withColor: .red, rect: CGRect(x: 0, y: 0, width: 3, height: 3))
+                    sut = ImageType.mock(withColor: .red, rect: CGRect(x: 0, y: 0, width: 3, height: 3))
                 }
 
                 it("returns .red") {
-                    expect(sut.averageColor()?.rgbaColor).to(equal(Color.red.rgbaColor))
+                    expect(sut.averageColor()?.rgbaColor).to(equal(ColorType.red.rgbaColor))
                 }
             }
         }

--- a/Example/Tests/Colors/Mocks/Image+mock.swift
+++ b/Example/Tests/Colors/Mocks/Image+mock.swift
@@ -15,8 +15,8 @@
 
 import CoreImage
 
-extension Image {
-    class func mock(withColor color: Color, rect: CGRect = CGRect(x: 0, y: 0, width: 1, height: 1)) -> Image {
+extension ImageType {
+    class func mock(withColor color: ColorType, rect: CGRect = CGRect(x: 0, y: 0, width: 1, height: 1)) -> ImageType {
         #if os(iOS) || os(tvOS)
 
             UIGraphicsBeginImageContext(rect.size)

--- a/Source/Colors/Extensions/Color+wcag.swift
+++ b/Source/Colors/Extensions/Color+wcag.swift
@@ -10,25 +10,25 @@
     import UIKit
 
     /// Typealias used for colors. It maps to UIColor.
-    public typealias Color = UIColor
+    public typealias ColorType = UIColor
 
     /// Typealias used for fonts. It maps to UIFont.
-    public typealias Font = UIFont
+    public typealias FontType = UIFont
 
 #elseif os(OSX)
 
     import AppKit
 
     /// Typealias used for colors. It maps to NSColor.
-    public typealias Color = NSColor
+    public typealias ColorType = NSColor
 
     /// Typealias used for fonts. It maps to NSFont.
-    public typealias Font = NSFont
+    public typealias FontType = NSFont
 
 #endif
 
 /// Extension that adds functionality for calculating WCAG compliant high contrast colors.
-extension Color {
+extension ColorType {
     /**
      Calculates the color ratio for a text color on a background color.
 
@@ -42,7 +42,7 @@ extension Color {
 
      - Warning: This function will also return `nil` if any input color is not convertable to the sRGB color space.
      */
-    public class func getContrastRatio(forTextColor textColor: Color, onBackgroundColor backgroundColor: Color) -> CGFloat? {
+    public class func getContrastRatio(forTextColor textColor: ColorType, onBackgroundColor backgroundColor: ColorType) -> CGFloat? {
         guard let rgbaTextColor = textColor.rgbaColor, let rgbaBackgroundColor = backgroundColor.rgbaColor else {
             return nil
         }
@@ -62,7 +62,7 @@ extension Color {
 
      - Warning: This function will also return `nil` if any input color is not convertable to the sRGB color space.
      */
-    public class func getTextColor(onBackgroundColor backgroundColor: Color) -> Color? {
+    public class func getTextColor(onBackgroundColor backgroundColor: ColorType) -> ColorType? {
         guard let rgbaBackgroundColor = backgroundColor.rgbaColor else { return nil }
         let textColor = RGBAColor.getTextColor(onBackgroundColor: rgbaBackgroundColor)
 
@@ -84,7 +84,7 @@ extension Color {
 
      - Warning: This function will also return `nil` if any input color is not convertable to the sRGB color space.
      */
-    public class func getTextColor(fromColors colors: [Color], withFont font: Font, onBackgroundColor backgroundColor: Color, conformanceLevel: ConformanceLevel = .AA) -> Color? {
+    public class func getTextColor(fromColors colors: [ColorType], withFont font: FontType, onBackgroundColor backgroundColor: ColorType, conformanceLevel: ConformanceLevel = .AA) -> ColorType? {
         guard let rgbaBackgroundColor = backgroundColor.rgbaColor else { return nil }
 
         for textColor in colors {
@@ -114,10 +114,10 @@ extension Color {
 
          - Warning: This function will also return `nil` if the image is corrupted.
          */
-        public class func getTextColor(onBackgroundImage image: Image, imageArea: ImageArea = .full) -> Color? {
+        public class func getTextColor(onBackgroundImage image: ImageType, imageArea: ImageArea = .full) -> ColorType? {
             guard let averageImageColor = image.averageColor(imageArea: imageArea) else { return nil }
 
-            return Color.getTextColor(onBackgroundColor: averageImageColor)
+            return ColorType.getTextColor(onBackgroundColor: averageImageColor)
         }
 
         /**
@@ -136,10 +136,10 @@ extension Color {
 
          - Warning: This function will also return `nil` if any input color is not convertable to the sRGB color space.
          */
-        public class func getTextColor(fromColors colors: [Color], withFont font: Font, onBackgroundImage image: Image, imageArea: ImageArea = .full, conformanceLevel: ConformanceLevel = .AA) -> Color? {
+        public class func getTextColor(fromColors colors: [ColorType], withFont font: FontType, onBackgroundImage image: ImageType, imageArea: ImageArea = .full, conformanceLevel: ConformanceLevel = .AA) -> ColorType? {
             guard let averageImageColor = image.averageColor(imageArea: imageArea) else { return nil }
 
-            return Color.getTextColor(fromColors: colors, withFont: font, onBackgroundColor: averageImageColor, conformanceLevel: conformanceLevel)
+            return ColorType.getTextColor(fromColors: colors, withFont: font, onBackgroundColor: averageImageColor, conformanceLevel: conformanceLevel)
         }
 
     #endif
@@ -156,7 +156,7 @@ extension Color {
 
      - Warning: This function will also return `nil` if any input color is not convertable to the sRGB color space.
      */
-    public class func getBackgroundColor(forTextColor textColor: Color) -> Color? {
+    public class func getBackgroundColor(forTextColor textColor: ColorType) -> ColorType? {
         guard let rgbaTextColor = textColor.rgbaColor else { return nil }
         let backgroundColor = RGBAColor.getBackgroundColor(forTextColor: rgbaTextColor)
 
@@ -178,7 +178,7 @@ extension Color {
 
      - Warning: This function will also return `nil` if any input color is not convertable to the sRGB color space.
      */
-    public class func getBackgroundColor(fromColors colors: [Color], forTextColor textColor: Color, withFont font: Font, conformanceLevel: ConformanceLevel = .AA) -> Color? {
+    public class func getBackgroundColor(fromColors colors: [ColorType], forTextColor textColor: ColorType, withFont font: FontType, conformanceLevel: ConformanceLevel = .AA) -> ColorType? {
         guard let rgbaTextColor = textColor.rgbaColor else { return nil }
 
         for backgroundColor in colors {

--- a/Source/Colors/Extensions/Image+averageColor.swift
+++ b/Source/Colors/Extensions/Image+averageColor.swift
@@ -12,21 +12,21 @@ import CoreGraphics
     import UIKit
 
     /// Typealias used for images. It maps to UIImage.
-    public typealias Image = UIImage
+    public typealias ImageType = UIImage
 
 #elseif os(OSX)
 
     import AppKit
 
     /// Typealias used for image. It maps to NSImage.
-    public typealias Image = NSImage
+    public typealias ImageType = NSImage
 
 #endif
 
 #if os(iOS) || os(tvOS) || os(OSX)
 
-    extension Image {
-        func averageColor(imageArea: ImageArea = .full) -> Color? {
+    extension ImageType {
+        func averageColor(imageArea: ImageArea = .full) -> ColorType? {
             let imageAreaRect = imageArea.rect(forImage: self)
             var transform = CGAffineTransform(scaleX: 1, y: -1)
             transform = transform.translatedBy(x: 0, y: -size.height)
@@ -43,7 +43,7 @@ import CoreGraphics
     }
 
     private extension CIImage {
-        func averageColor(in rect: CGRect) -> Color? {
+        func averageColor(in rect: CGRect) -> ColorType? {
             let extentVector = CIVector(x: rect.origin.x, y: rect.origin.y, z: rect.size.width, w: rect.size.height)
 
             guard
@@ -56,7 +56,7 @@ import CoreGraphics
             var bitmap = [UInt8](repeating: 0, count: 4)
             let context = CIContext(options: [.workingColorSpace: kCFNull as Any])
             context.render(imageSection, toBitmap: &bitmap, rowBytes: 4, bounds: CGRect(x: 0, y: 0, width: 1, height: 1), format: .RGBA8, colorSpace: nil)
-            let averageColor = Color(
+            let averageColor = ColorType(
                 red: CGFloat(bitmap[0]) / 255,
                 green: CGFloat(bitmap[1]) / 255,
                 blue: CGFloat(bitmap[2]) / 255,

--- a/Source/Colors/Models/ImageArea.swift
+++ b/Source/Colors/Models/ImageArea.swift
@@ -61,7 +61,7 @@
         /// The second horizontal third.
         case verticalCenter
 
-        func rect(forImage image: Image) -> CGRect {
+        func rect(forImage image: ImageType) -> CGRect {
             let imageWidth = image.size.width
             let imageHeight = image.size.height
             let widthThird = imageWidth / 3.0


### PR DESCRIPTION
## Issue information
Capable is using typealias names (e.g. `NSColor`, `UIColor`) inside extensions  to avoid code duplication. When using the framework along with SwiftUI, building fails due to naming collisions (SwiftUI `Color` and typealias `Color` for `NSColor`, `UIColor`).

## Goal
Avoid naming collisions 😁 

## Implementation
Rename typealias names

## Testing
Run Unit Tests