### PR TITLE
Fix naming collisions with SwiftUI

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,11 +1,11 @@
 PODS:
-  - Capable (1.1.1):
-    - Capable/Colors (= 1.1.1)
-    - Capable/Features (= 1.1.1)
-    - Capable/Fonts (= 1.1.1)
-  - Capable/Colors (1.1.1)
-  - Capable/Features (1.1.1)
-  - Capable/Fonts (1.1.1)
+  - Capable (1.1.2):
+    - Capable/Colors (= 1.1.2)
+    - Capable/Features (= 1.1.2)
+    - Capable/Fonts (= 1.1.2)
+  - Capable/Colors (1.1.2)
+  - Capable/Features (1.1.2)
+  - Capable/Fonts (1.1.2)
   - Nimble (8.0.4)
   - Quick (2.2.0)
   - SheetyColors (1.0.1):
@@ -18,7 +18,7 @@ DEPENDENCIES:
   - SheetyColors (= 1.0.1)
 
 SPEC REPOS:
-  https://github.com/CocoaPods/Specs.git:
+  trunk:
     - Nimble
     - Quick
     - SheetyColors
@@ -28,7 +28,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  Capable: c9a4ee37bb727af2255879f32e56b5cfa04857a5
+  Capable: 68f8213fb81f2e4667bcc06449adc6ade1926017
   Nimble: 18d5360282923225d62b09d781f63abc1a0111fc
   Quick: 7fb19e13be07b5dfb3b90d4f9824c855a11af40e
   SheetyColors: ae8c3a5d04d310e8e2d08e4aa0bd543519d02252

--- a/Example/Pods/Target Support Files/Capable-iOS/Capable-iOS-Info.plist
+++ b/Example/Pods/Target Support Files/Capable-iOS/Capable-iOS-Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>1.1.1</string>
+  <string>1.1.2</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/Example/Pods/Target Support Files/Capable-macOS/Capable-macOS-Info.plist
+++ b/Example/Pods/Target Support Files/Capable-macOS/Capable-macOS-Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>1.1.1</string>
+  <string>1.1.2</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/Example/Pods/Target Support Files/Capable-tvOS/Capable-tvOS-Info.plist
+++ b/Example/Pods/Target Support Files/Capable-tvOS/Capable-tvOS-Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>1.1.1</string>
+  <string>1.1.2</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/Example/Pods/Target Support Files/Capable-watchOS/Capable-watchOS-Info.plist
+++ b/Example/Pods/Target Support Files/Capable-watchOS/Capable-watchOS-Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>1.1.1</string>
+  <string>1.1.2</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/Example/Source/Color+capable.swift
+++ b/Example/Source/Color+capable.swift
@@ -9,21 +9,21 @@
 #if os(iOS)
 
     import UIKit
-    typealias Color = UIColor
+    typealias TypeColor = UIColor
 
 #elseif os(OSX)
 
     import AppKit
-    typealias Color = NSColor
+    typealias TypeColor = NSColor
 
 #endif
 
-extension Color {
-    static var capableGreen: Color {
-        return Color(red: 137 / 255.0, green: 176 / 255.0, blue: 106 / 255.0, alpha: 1.0)
+extension TypeColor {
+    static var capableGreen: TypeColor {
+        return TypeColor(red: 137 / 255.0, green: 176 / 255.0, blue: 106 / 255.0, alpha: 1.0)
     }
 
-    static var capableRed: Color {
-        return Color(red: 1.0, green: 120 / 255.0, blue: 120 / 255.0, alpha: 1.0)
+    static var capableRed: TypeColor {
+        return TypeColor(red: 1.0, green: 120 / 255.0, blue: 120 / 255.0, alpha: 1.0)
     }
 }

--- a/Example/Source/ConformanceLevelView.swift
+++ b/Example/Source/ConformanceLevelView.swift
@@ -9,14 +9,14 @@
 #if os(iOS)
 
     import UIKit
-    typealias Font = UIFont
+    typealias TypeFont = UIFont
     typealias Label = UILabel
     typealias View = UIView
 
 #elseif os(OSX)
 
     import AppKit
-    typealias Font = NSFont
+    typealias TypeFont = NSFont
     typealias Label = NSTextField
     typealias View = NSView
 
@@ -38,8 +38,8 @@ class ConformanceLevelView: View {
 
     var isPassing: Bool = false {
         didSet {
-            self.backgroundColor = isPassing ? Color.capableGreen : Color.capableRed
-            self.textLabel.textColor = Color.getTextColor(onBackgroundColor: self.backgroundColor!)!
+            self.backgroundColor = isPassing ? TypeColor.capableGreen : TypeColor.capableRed
+            self.textLabel.textColor = TypeColor.getTextColor(onBackgroundColor: self.backgroundColor!)!
         }
     }
 
@@ -50,7 +50,7 @@ class ConformanceLevelView: View {
 
     func setupView() {
         addSubview(textLabel)
-        textLabel.font = Font.systemFont(ofSize: 13.0)
+        textLabel.font = TypeFont.systemFont(ofSize: 13.0)
 
         textLabel.translatesAutoresizingMaskIntoConstraints = false
         let views: [String: Any] = ["textLabel": self.textLabel]

--- a/Example/Tests/Colors/ColorWcagTests.swift
+++ b/Example/Tests/Colors/ColorWcagTests.swift
@@ -45,9 +45,9 @@ import Quick
 class ColorWcagTests: QuickSpec {
     override func spec() {
         struct Fonts {
-            static let smallFont = Font.systemFont(ofSize: 14.0)
-            static let smallBoldFont = Font.boldSystemFont(ofSize: 14.0)
-            static let largeFont = Font.systemFont(ofSize: 18.0)
+            static let smallFont = TypeFont.systemFont(ofSize: 14.0)
+            static let smallBoldFont = TypeFont.boldSystemFont(ofSize: 14.0)
+            static let largeFont = TypeFont.systemFont(ofSize: 18.0)
         }
 
         describe("The UIColor/NSColor class") {
@@ -111,19 +111,19 @@ class ColorWcagTests: QuickSpec {
             context("when calling getContrastRatio") {
                 context("by passing in the same color twice") {
                     it("returns the minimum contrast ratio of 1.0") {
-                        expect(Color.getContrastRatio(forTextColor: Colors.white, onBackgroundColor: Colors.white)).to(equal(1.0))
+                        expect(TypeColor.getContrastRatio(forTextColor: Colors.white, onBackgroundColor: Colors.white)).to(equal(1.0))
                     }
                 }
 
                 context("by passing in white and black") {
                     it("returns the maximum contrast ratio of 21.0") {
-                        expect(Color.getContrastRatio(forTextColor: Colors.white, onBackgroundColor: Colors.black)).to(equal(21.0))
+                        expect(TypeColor.getContrastRatio(forTextColor: Colors.white, onBackgroundColor: Colors.black)).to(equal(21.0))
                     }
                 }
 
                 context("by passing in green and orange color") {
                     it("returns a contrast ratio of 2.31") {
-                        let actualContrastRatio = Color.getContrastRatio(forTextColor: Colors.colorWithContrastRatio3, onBackgroundColor: Colors.colorWithContrastRatio7)!
+                        let actualContrastRatio = TypeColor.getContrastRatio(forTextColor: Colors.colorWithContrastRatio3, onBackgroundColor: Colors.colorWithContrastRatio7)!
                         let rounded = floor(actualContrastRatio * 100) / 100
 
                         expect(rounded).to(equal(2.3))
@@ -132,7 +132,7 @@ class ColorWcagTests: QuickSpec {
 
                 context("by passing in semi transparent color and white") {
                     it("returns a contrast ratio of 4.51") {
-                        let actualContrastRatio = Color.getContrastRatio(forTextColor: Colors.semiTransparentColor, onBackgroundColor: Colors.white)!
+                        let actualContrastRatio = TypeColor.getContrastRatio(forTextColor: Colors.semiTransparentColor, onBackgroundColor: Colors.white)!
                         let rounded = floor(actualContrastRatio * 100) / 100
 
                         expect(rounded).to(equal(4.51))
@@ -143,30 +143,30 @@ class ColorWcagTests: QuickSpec {
             context("when calling getTextColor") {
                 context("by passing in a dark background color") {
                     it("returns white") {
-                        let actual = Color.getTextColor(onBackgroundColor: Colors.black)
+                        let actual = TypeColor.getTextColor(onBackgroundColor: Colors.black)
 
-                        expect(actual).to(equal(Color.white))
+                        expect(actual).to(equal(TypeColor.white))
                     }
                 }
 
                 context("by passing in a light background color") {
                     it("returns black") {
-                        let actual = Color.getTextColor(onBackgroundColor: Colors.white)
+                        let actual = TypeColor.getTextColor(onBackgroundColor: Colors.white)
 
-                        expect(actual).to(equal(Color.black))
+                        expect(actual).to(equal(TypeColor.black))
                     }
                 }
 
                 context("by passing in a background color with a medium relative luminance") {
                     it("returns black") {
-                        let actual = Color.getTextColor(onBackgroundColor: Colors.colorWithContrastRatio4_5)
+                        let actual = TypeColor.getTextColor(onBackgroundColor: Colors.colorWithContrastRatio4_5)
 
-                        expect(actual).to(equal(Color.black))
+                        expect(actual).to(equal(TypeColor.black))
                     }
                 }
 
                 context("by passing a background color and a list of text colors") {
-                    var colors: [Color]?
+                    var colors: [TypeColor]?
 
                     beforeEach {
                         colors = [
@@ -178,7 +178,7 @@ class ColorWcagTests: QuickSpec {
 
                     context("by not providing any passing color") {
                         it("returns nil") {
-                            let actual = Color.getTextColor(fromColors: [], withFont: Fonts.smallFont, onBackgroundColor: Colors.white, conformanceLevel: .AA)
+                            let actual = TypeColor.getTextColor(fromColors: [], withFont: Fonts.smallFont, onBackgroundColor: Colors.white, conformanceLevel: .AA)
 
                             expect(actual).to(beNil())
                         }
@@ -187,7 +187,7 @@ class ColorWcagTests: QuickSpec {
                     context("when defining conformance level .AA") {
                         context("when using a small font") {
                             it("returns black") {
-                                let actual = Color.getTextColor(fromColors: colors!, withFont: Fonts.smallFont, onBackgroundColor: Colors.white, conformanceLevel: .AA)
+                                let actual = TypeColor.getTextColor(fromColors: colors!, withFont: Fonts.smallFont, onBackgroundColor: Colors.white, conformanceLevel: .AA)
 
                                 expect(actual).to(equal(Colors.colorWithContrastRatio4_5))
                             }
@@ -195,7 +195,7 @@ class ColorWcagTests: QuickSpec {
 
                         context("when using a small bold font") {
                             it("returns black") {
-                                let actual = Color.getTextColor(fromColors: colors!, withFont: Fonts.smallBoldFont, onBackgroundColor: Colors.white, conformanceLevel: .AA)
+                                let actual = TypeColor.getTextColor(fromColors: colors!, withFont: Fonts.smallBoldFont, onBackgroundColor: Colors.white, conformanceLevel: .AA)
 
                                 expect(actual).to(equal(Colors.colorWithContrastRatio3))
                             }
@@ -203,7 +203,7 @@ class ColorWcagTests: QuickSpec {
 
                         context("when using a large font") {
                             it("returns black") {
-                                let actual = Color.getTextColor(fromColors: colors!, withFont: Fonts.largeFont, onBackgroundColor: Colors.white, conformanceLevel: .AA)
+                                let actual = TypeColor.getTextColor(fromColors: colors!, withFont: Fonts.largeFont, onBackgroundColor: Colors.white, conformanceLevel: .AA)
 
                                 expect(actual).to(equal(Colors.colorWithContrastRatio3))
                             }
@@ -213,7 +213,7 @@ class ColorWcagTests: QuickSpec {
                     context("when defining conformance level .AAA") {
                         context("when using a small font") {
                             it("returns black") {
-                                let actual = Color.getTextColor(fromColors: colors!, withFont: Fonts.smallFont, onBackgroundColor: Colors.white, conformanceLevel: .AAA)
+                                let actual = TypeColor.getTextColor(fromColors: colors!, withFont: Fonts.smallFont, onBackgroundColor: Colors.white, conformanceLevel: .AAA)
 
                                 expect(actual).to(equal(Colors.colorWithContrastRatio7))
                             }
@@ -221,7 +221,7 @@ class ColorWcagTests: QuickSpec {
 
                         context("when using a small bold font") {
                             it("returns black") {
-                                let actual = Color.getTextColor(fromColors: colors!, withFont: Fonts.smallBoldFont, onBackgroundColor: Colors.white, conformanceLevel: .AAA)
+                                let actual = TypeColor.getTextColor(fromColors: colors!, withFont: Fonts.smallBoldFont, onBackgroundColor: Colors.white, conformanceLevel: .AAA)
 
                                 expect(actual).to(equal(Colors.colorWithContrastRatio4_5))
                             }
@@ -229,7 +229,7 @@ class ColorWcagTests: QuickSpec {
 
                         context("when using a large font") {
                             it("returns black") {
-                                let actual = Color.getTextColor(fromColors: colors!, withFont: Fonts.largeFont, onBackgroundColor: Colors.white, conformanceLevel: .AAA)
+                                let actual = TypeColor.getTextColor(fromColors: colors!, withFont: Fonts.largeFont, onBackgroundColor: Colors.white, conformanceLevel: .AAA)
 
                                 expect(actual).to(equal(Colors.colorWithContrastRatio4_5))
                             }
@@ -241,37 +241,37 @@ class ColorWcagTests: QuickSpec {
 
                     context("by passing in a dark background image") {
                         it("returns white") {
-                            let backgroundImage = Image.mock(withColor: Colors.black)
-                            let actual = Color.getTextColor(onBackgroundImage: backgroundImage)
+                            let backgroundImage = TypeImage.mock(withColor: Colors.black)
+                            let actual = TypeColor.getTextColor(onBackgroundImage: backgroundImage)
 
-                            expect(actual).to(equal(Color.white))
+                            expect(actual).to(equal(TypeColor.white))
                         }
                     }
 
                     context("by passing in a light background image") {
                         it("returns black") {
-                            let backgroundImage = Image.mock(withColor: Colors.white)
-                            let actual = Color.getTextColor(onBackgroundImage: backgroundImage)
+                            let backgroundImage = TypeImage.mock(withColor: Colors.white)
+                            let actual = TypeColor.getTextColor(onBackgroundImage: backgroundImage)
 
-                            expect(actual).to(equal(Color.black))
+                            expect(actual).to(equal(TypeColor.black))
                         }
                     }
 
                     context("by passing in a background image with a medium relative luminance") {
                         it("returns black") {
-                            let backgroundImage = Image.mock(withColor: Colors.colorWithContrastRatio4_5)
-                            let actual = Color.getTextColor(onBackgroundImage: backgroundImage)
+                            let backgroundImage = TypeImage.mock(withColor: Colors.colorWithContrastRatio4_5)
+                            let actual = TypeColor.getTextColor(onBackgroundImage: backgroundImage)
 
-                            expect(actual).to(equal(Color.black))
+                            expect(actual).to(equal(TypeColor.black))
                         }
                     }
 
                     context("by passing a background image and a list of text colors") {
-                        var colors: [Color]!
-                        var backgroundImage: Image!
+                        var colors: [TypeColor]!
+                        var backgroundImage: TypeImage!
 
                         beforeEach {
-                            backgroundImage = Image.mock(withColor: Colors.white)
+                            backgroundImage = TypeImage.mock(withColor: Colors.white)
                             colors = [
                                 Colors.colorWithContrastRatio3,
                                 Colors.colorWithContrastRatio4_5,
@@ -281,7 +281,7 @@ class ColorWcagTests: QuickSpec {
 
                         context("by not providing any passing color") {
                             it("returns nil") {
-                                let actual = Color.getTextColor(fromColors: [], withFont: Fonts.smallFont, onBackgroundImage: backgroundImage, conformanceLevel: .AA)
+                                let actual = TypeColor.getTextColor(fromColors: [], withFont: Fonts.smallFont, onBackgroundImage: backgroundImage, conformanceLevel: .AA)
 
                                 expect(actual).to(beNil())
                             }
@@ -290,7 +290,7 @@ class ColorWcagTests: QuickSpec {
                         context("when defining conformance level .AA") {
                             context("when using a small font") {
                                 it("returns a color of conformance level 4.5") {
-                                    let actual = Color.getTextColor(fromColors: colors, withFont: Fonts.smallFont, onBackgroundImage: backgroundImage, conformanceLevel: .AA)
+                                    let actual = TypeColor.getTextColor(fromColors: colors, withFont: Fonts.smallFont, onBackgroundImage: backgroundImage, conformanceLevel: .AA)
 
                                     expect(actual).to(equal(Colors.colorWithContrastRatio4_5))
                                 }
@@ -298,7 +298,7 @@ class ColorWcagTests: QuickSpec {
 
                             context("when using a small bold font") {
                                 it("returns a color of conformance level 3") {
-                                    let actual = Color.getTextColor(fromColors: colors, withFont: Fonts.smallBoldFont, onBackgroundImage: backgroundImage, conformanceLevel: .AA)
+                                    let actual = TypeColor.getTextColor(fromColors: colors, withFont: Fonts.smallBoldFont, onBackgroundImage: backgroundImage, conformanceLevel: .AA)
 
                                     expect(actual).to(equal(Colors.colorWithContrastRatio3))
                                 }
@@ -306,7 +306,7 @@ class ColorWcagTests: QuickSpec {
 
                             context("when using a large font") {
                                 it("returns a color of conformance level 3") {
-                                    let actual = Color.getTextColor(fromColors: colors, withFont: Fonts.largeFont, onBackgroundImage: backgroundImage, conformanceLevel: .AA)
+                                    let actual = TypeColor.getTextColor(fromColors: colors, withFont: Fonts.largeFont, onBackgroundImage: backgroundImage, conformanceLevel: .AA)
 
                                     expect(actual).to(equal(Colors.colorWithContrastRatio3))
                                 }
@@ -316,7 +316,7 @@ class ColorWcagTests: QuickSpec {
                         context("when defining conformance level .AAA") {
                             context("when using a small font") {
                                 it("returns a color of conformance level 7") {
-                                    let actual = Color.getTextColor(fromColors: colors, withFont: Fonts.smallFont, onBackgroundImage: backgroundImage, conformanceLevel: .AAA)
+                                    let actual = TypeColor.getTextColor(fromColors: colors, withFont: Fonts.smallFont, onBackgroundImage: backgroundImage, conformanceLevel: .AAA)
 
                                     expect(actual).to(equal(Colors.colorWithContrastRatio7))
                                 }
@@ -324,7 +324,7 @@ class ColorWcagTests: QuickSpec {
 
                             context("when using a small bold font") {
                                 it("returns a color of conformance level 4.5") {
-                                    let actual = Color.getTextColor(fromColors: colors, withFont: Fonts.smallBoldFont, onBackgroundImage: backgroundImage, conformanceLevel: .AAA)
+                                    let actual = TypeColor.getTextColor(fromColors: colors, withFont: Fonts.smallBoldFont, onBackgroundImage: backgroundImage, conformanceLevel: .AAA)
 
                                     expect(actual).to(equal(Colors.colorWithContrastRatio4_5))
                                 }
@@ -332,7 +332,7 @@ class ColorWcagTests: QuickSpec {
 
                             context("when using a large font") {
                                 it("returns a color of conformance level 4.5") {
-                                    let actual = Color.getTextColor(fromColors: colors, withFont: Fonts.largeFont, onBackgroundImage: backgroundImage, conformanceLevel: .AAA)
+                                    let actual = TypeColor.getTextColor(fromColors: colors, withFont: Fonts.largeFont, onBackgroundImage: backgroundImage, conformanceLevel: .AAA)
 
                                     expect(actual).to(equal(Colors.colorWithContrastRatio4_5))
                                 }
@@ -346,31 +346,31 @@ class ColorWcagTests: QuickSpec {
             context("when calling getBackgroundColor") {
                 context("by passing in a dark text color") {
                     it("returns white") {
-                        let actual = Color.getBackgroundColor(forTextColor: Colors.black)
+                        let actual = TypeColor.getBackgroundColor(forTextColor: Colors.black)
 
-                        expect(actual).to(equal(Color.white))
+                        expect(actual).to(equal(TypeColor.white))
                     }
                 }
 
                 context("by passing in a light text color") {
                     it("returns black") {
-                        let actual = Color.getBackgroundColor(forTextColor: Colors.white)
+                        let actual = TypeColor.getBackgroundColor(forTextColor: Colors.white)
 
-                        expect(actual).to(equal(Color.black))
+                        expect(actual).to(equal(TypeColor.black))
                     }
                 }
 
                 context("by passing in a text color with a medium relative luminance") {
                     it("returns black") {
-                        let actual = Color.getBackgroundColor(forTextColor: Colors.colorWithContrastRatio4_5)
+                        let actual = TypeColor.getBackgroundColor(forTextColor: Colors.colorWithContrastRatio4_5)
 
-                        expect(actual).to(equal(Color.black))
+                        expect(actual).to(equal(TypeColor.black))
                     }
                 }
             }
 
             context("when calling getBackgroundColor with a list of colors") {
-                var colors: [Color]?
+                var colors: [TypeColor]?
 
                 beforeEach {
                     colors = [
@@ -382,7 +382,7 @@ class ColorWcagTests: QuickSpec {
 
                 context("by not providing any passing color") {
                     it("returns nil") {
-                        let actual = Color.getBackgroundColor(fromColors: [], forTextColor: Colors.white, withFont: Fonts.smallFont, conformanceLevel: .AA)
+                        let actual = TypeColor.getBackgroundColor(fromColors: [], forTextColor: Colors.white, withFont: Fonts.smallFont, conformanceLevel: .AA)
 
                         expect(actual).to(beNil())
                     }
@@ -391,7 +391,7 @@ class ColorWcagTests: QuickSpec {
                 context("when defining conformance level .AA") {
                     context("when using a small font") {
                         it("returns a color of conformance level 4.5") {
-                            let actual = Color.getBackgroundColor(fromColors: colors!, forTextColor: Colors.white, withFont: Fonts.smallFont, conformanceLevel: .AA)
+                            let actual = TypeColor.getBackgroundColor(fromColors: colors!, forTextColor: Colors.white, withFont: Fonts.smallFont, conformanceLevel: .AA)
 
                             expect(actual).to(equal(Colors.colorWithContrastRatio4_5))
                         }
@@ -399,7 +399,7 @@ class ColorWcagTests: QuickSpec {
 
                     context("when using a small bold font") {
                         it("returns a color of conformance level 3") {
-                            let actual = Color.getBackgroundColor(fromColors: colors!, forTextColor: Colors.white, withFont: Fonts.smallBoldFont, conformanceLevel: .AA)
+                            let actual = TypeColor.getBackgroundColor(fromColors: colors!, forTextColor: Colors.white, withFont: Fonts.smallBoldFont, conformanceLevel: .AA)
 
                             expect(actual).to(equal(Colors.colorWithContrastRatio3))
                         }
@@ -407,7 +407,7 @@ class ColorWcagTests: QuickSpec {
 
                     context("when using a large font") {
                         it("returns a color of conformance level 3") {
-                            let actual = Color.getBackgroundColor(fromColors: colors!, forTextColor: Colors.white, withFont: Fonts.largeFont, conformanceLevel: .AA)
+                            let actual = TypeColor.getBackgroundColor(fromColors: colors!, forTextColor: Colors.white, withFont: Fonts.largeFont, conformanceLevel: .AA)
 
                             expect(actual).to(equal(Colors.colorWithContrastRatio3))
                         }
@@ -417,7 +417,7 @@ class ColorWcagTests: QuickSpec {
                 context("when defining conformance level .AAA") {
                     context("when using a small font") {
                         it("returns a color of conformance level 7") {
-                            let actual = Color.getBackgroundColor(fromColors: colors!, forTextColor: Colors.white, withFont: Fonts.smallFont, conformanceLevel: .AAA)
+                            let actual = TypeColor.getBackgroundColor(fromColors: colors!, forTextColor: Colors.white, withFont: Fonts.smallFont, conformanceLevel: .AAA)
 
                             expect(actual).to(equal(Colors.colorWithContrastRatio7))
                         }
@@ -425,7 +425,7 @@ class ColorWcagTests: QuickSpec {
 
                     context("when using a small bold font") {
                         it("returns a color of conformance level 4.5") {
-                            let actual = Color.getBackgroundColor(fromColors: colors!, forTextColor: Colors.white, withFont: Fonts.smallBoldFont, conformanceLevel: .AAA)
+                            let actual = TypeColor.getBackgroundColor(fromColors: colors!, forTextColor: Colors.white, withFont: Fonts.smallBoldFont, conformanceLevel: .AAA)
 
                             expect(actual).to(equal(Colors.colorWithContrastRatio4_5))
                         }
@@ -433,7 +433,7 @@ class ColorWcagTests: QuickSpec {
 
                     context("when using a large font") {
                         it("returns a color of conformance level 4.5") {
-                            let actual = Color.getBackgroundColor(fromColors: colors!, forTextColor: Colors.white, withFont: Fonts.largeFont, conformanceLevel: .AAA)
+                            let actual = TypeColor.getBackgroundColor(fromColors: colors!, forTextColor: Colors.white, withFont: Fonts.largeFont, conformanceLevel: .AAA)
 
                             expect(actual).to(equal(Colors.colorWithContrastRatio4_5))
                         }

--- a/Example/Tests/Colors/ImageAreaTests.swift
+++ b/Example/Tests/Colors/ImageAreaTests.swift
@@ -13,7 +13,7 @@ class ImageAreaTests: QuickSpec {
     override func spec() {
         describe("The ImageArea class") {
             var sut: ImageArea!
-            let testImage = Image.mock(withColor: .white, rect: CGRect(x: 0, y: 0, width: 3, height: 3))
+            let testImage = TypeImage.mock(withColor: .white, rect: CGRect(x: 0, y: 0, width: 3, height: 3))
 
             context("calling rect()") {
                 var actualRect: CGRect!

--- a/Example/Tests/Colors/ImageAverageColorTests.swift
+++ b/Example/Tests/Colors/ImageAverageColorTests.swift
@@ -12,15 +12,15 @@ import Quick
 class ImageAverageColorTests: QuickSpec {
     override func spec() {
         describe("The UIImage/NSImage class") {
-            var sut: Image!
+            var sut: TypeImage!
 
             context("when calling averageColor() for a red image") {
                 beforeEach {
-                    sut = Image.mock(withColor: .red, rect: CGRect(x: 0, y: 0, width: 3, height: 3))
+                    sut = TypeImage.mock(withColor: .red, rect: CGRect(x: 0, y: 0, width: 3, height: 3))
                 }
 
                 it("returns .red") {
-                    expect(sut.averageColor()?.rgbaColor).to(equal(Color.red.rgbaColor))
+                    expect(sut.averageColor()?.rgbaColor).to(equal(TypeColor.red.rgbaColor))
                 }
             }
         }

--- a/Example/Tests/Colors/Mocks/Image+mock.swift
+++ b/Example/Tests/Colors/Mocks/Image+mock.swift
@@ -15,8 +15,8 @@
 
 import CoreImage
 
-extension Image {
-    class func mock(withColor color: Color, rect: CGRect = CGRect(x: 0, y: 0, width: 1, height: 1)) -> Image {
+extension TypeImage {
+    class func mock(withColor color: TypeColor, rect: CGRect = CGRect(x: 0, y: 0, width: 1, height: 1)) -> TypeImage {
         #if os(iOS) || os(tvOS)
 
             UIGraphicsBeginImageContext(rect.size)
@@ -37,7 +37,7 @@ extension Image {
                 fatalError("Error creating the mock image.")
             }
 
-            return Image(cgImage: cgImage, size: rect.size)
+            return TypeImage(cgImage: cgImage, size: rect.size)
 
         #endif
     }

--- a/Source/Colors/Extensions/Color+wcag.swift
+++ b/Source/Colors/Extensions/Color+wcag.swift
@@ -10,25 +10,25 @@
     import UIKit
 
     /// Typealias used for colors. It maps to UIColor.
-    public typealias Color = UIColor
+    public typealias TypeColor = UIColor
 
     /// Typealias used for fonts. It maps to UIFont.
-    public typealias Font = UIFont
+    public typealias TypeFont = UIFont
 
 #elseif os(OSX)
 
     import AppKit
 
     /// Typealias used for colors. It maps to NSColor.
-    public typealias Color = NSColor
+    public typealias TypeColor = NSColor
 
     /// Typealias used for fonts. It maps to NSFont.
-    public typealias Font = NSFont
+    public typealias TypeFont = NSFont
 
 #endif
 
 /// Extension that adds functionality for calculating WCAG compliant high contrast colors.
-extension Color {
+extension TypeColor {
     /**
      Calculates the color ratio for a text color on a background color.
 
@@ -42,7 +42,7 @@ extension Color {
 
      - Warning: This function will also return `nil` if any input color is not convertable to the sRGB color space.
      */
-    public class func getContrastRatio(forTextColor textColor: Color, onBackgroundColor backgroundColor: Color) -> CGFloat? {
+    public class func getContrastRatio(forTextColor textColor: TypeColor, onBackgroundColor backgroundColor: TypeColor) -> CGFloat? {
         guard let rgbaTextColor = textColor.rgbaColor, let rgbaBackgroundColor = backgroundColor.rgbaColor else {
             return nil
         }
@@ -62,7 +62,7 @@ extension Color {
 
      - Warning: This function will also return `nil` if any input color is not convertable to the sRGB color space.
      */
-    public class func getTextColor(onBackgroundColor backgroundColor: Color) -> Color? {
+    public class func getTextColor(onBackgroundColor backgroundColor: TypeColor) -> TypeColor? {
         guard let rgbaBackgroundColor = backgroundColor.rgbaColor else { return nil }
         let textColor = RGBAColor.getTextColor(onBackgroundColor: rgbaBackgroundColor)
 
@@ -84,7 +84,7 @@ extension Color {
 
      - Warning: This function will also return `nil` if any input color is not convertable to the sRGB color space.
      */
-    public class func getTextColor(fromColors colors: [Color], withFont font: Font, onBackgroundColor backgroundColor: Color, conformanceLevel: ConformanceLevel = .AA) -> Color? {
+    public class func getTextColor(fromColors colors: [TypeColor], withFont font: TypeFont, onBackgroundColor backgroundColor: TypeColor, conformanceLevel: ConformanceLevel = .AA) -> TypeColor? {
         guard let rgbaBackgroundColor = backgroundColor.rgbaColor else { return nil }
 
         for textColor in colors {
@@ -114,10 +114,10 @@ extension Color {
 
          - Warning: This function will also return `nil` if the image is corrupted.
          */
-        public class func getTextColor(onBackgroundImage image: Image, imageArea: ImageArea = .full) -> Color? {
+        public class func getTextColor(onBackgroundImage image: TypeImage, imageArea: ImageArea = .full) -> TypeColor? {
             guard let averageImageColor = image.averageColor(imageArea: imageArea) else { return nil }
 
-            return Color.getTextColor(onBackgroundColor: averageImageColor)
+            return TypeColor.getTextColor(onBackgroundColor: averageImageColor)
         }
 
         /**
@@ -136,10 +136,10 @@ extension Color {
 
          - Warning: This function will also return `nil` if any input color is not convertable to the sRGB color space.
          */
-        public class func getTextColor(fromColors colors: [Color], withFont font: Font, onBackgroundImage image: Image, imageArea: ImageArea = .full, conformanceLevel: ConformanceLevel = .AA) -> Color? {
+        public class func getTextColor(fromColors colors: [TypeColor], withFont font: TypeFont, onBackgroundImage image: TypeImage, imageArea: ImageArea = .full, conformanceLevel: ConformanceLevel = .AA) -> TypeColor? {
             guard let averageImageColor = image.averageColor(imageArea: imageArea) else { return nil }
 
-            return Color.getTextColor(fromColors: colors, withFont: font, onBackgroundColor: averageImageColor, conformanceLevel: conformanceLevel)
+            return TypeColor.getTextColor(fromColors: colors, withFont: font, onBackgroundColor: averageImageColor, conformanceLevel: conformanceLevel)
         }
 
     #endif
@@ -156,7 +156,7 @@ extension Color {
 
      - Warning: This function will also return `nil` if any input color is not convertable to the sRGB color space.
      */
-    public class func getBackgroundColor(forTextColor textColor: Color) -> Color? {
+    public class func getBackgroundColor(forTextColor textColor: TypeColor) -> TypeColor? {
         guard let rgbaTextColor = textColor.rgbaColor else { return nil }
         let backgroundColor = RGBAColor.getBackgroundColor(forTextColor: rgbaTextColor)
 
@@ -178,7 +178,7 @@ extension Color {
 
      - Warning: This function will also return `nil` if any input color is not convertable to the sRGB color space.
      */
-    public class func getBackgroundColor(fromColors colors: [Color], forTextColor textColor: Color, withFont font: Font, conformanceLevel: ConformanceLevel = .AA) -> Color? {
+    public class func getBackgroundColor(fromColors colors: [TypeColor], forTextColor textColor: TypeColor, withFont font: TypeFont, conformanceLevel: ConformanceLevel = .AA) -> TypeColor? {
         guard let rgbaTextColor = textColor.rgbaColor else { return nil }
 
         for backgroundColor in colors {

--- a/Source/Colors/Extensions/Image+averageColor.swift
+++ b/Source/Colors/Extensions/Image+averageColor.swift
@@ -12,21 +12,21 @@ import CoreGraphics
     import UIKit
 
     /// Typealias used for images. It maps to UIImage.
-    public typealias Image = UIImage
+    public typealias TypeImage = UIImage
 
 #elseif os(OSX)
 
     import AppKit
 
     /// Typealias used for image. It maps to NSImage.
-    public typealias Image = NSImage
+    public typealias TypeImage = NSImage
 
 #endif
 
 #if os(iOS) || os(tvOS) || os(OSX)
 
-    extension Image {
-        func averageColor(imageArea: ImageArea = .full) -> Color? {
+    extension TypeImage {
+        func averageColor(imageArea: ImageArea = .full) -> TypeColor? {
             let imageAreaRect = imageArea.rect(forImage: self)
             var transform = CGAffineTransform(scaleX: 1, y: -1)
             transform = transform.translatedBy(x: 0, y: -size.height)
@@ -43,7 +43,7 @@ import CoreGraphics
     }
 
     private extension CIImage {
-        func averageColor(in rect: CGRect) -> Color? {
+        func averageColor(in rect: CGRect) -> TypeColor? {
             let extentVector = CIVector(x: rect.origin.x, y: rect.origin.y, z: rect.size.width, w: rect.size.height)
 
             guard
@@ -56,7 +56,7 @@ import CoreGraphics
             var bitmap = [UInt8](repeating: 0, count: 4)
             let context = CIContext(options: [.workingColorSpace: kCFNull as Any])
             context.render(imageSection, toBitmap: &bitmap, rowBytes: 4, bounds: CGRect(x: 0, y: 0, width: 1, height: 1), format: .RGBA8, colorSpace: nil)
-            let averageColor = Color(
+            let averageColor = TypeColor(
                 red: CGFloat(bitmap[0]) / 255,
                 green: CGFloat(bitmap[1]) / 255,
                 blue: CGFloat(bitmap[2]) / 255,

--- a/Source/Colors/Models/ImageArea.swift
+++ b/Source/Colors/Models/ImageArea.swift
@@ -61,7 +61,7 @@
         /// The second horizontal third.
         case verticalCenter
 
-        func rect(forImage image: Image) -> CGRect {
+        func rect(forImage image: TypeImage) -> CGRect {
             let imageWidth = image.size.width
             let imageHeight = image.size.height
             let widthThird = imageWidth / 3.0


### PR DESCRIPTION
## Issue information
Capable is using typealias names (e.g. `NSColor`, `UIColor`) inside extensions  to avoid code duplication. When using the framework along with SwiftUI, building fails due to naming collisions (SwiftUI `Color` and typealias `Color` for `NSColor`, `UIColor`).

## Goal
Avoid naming collisions 😁 

## Implementation
Rename typealias names

## Testing
Run Unit Tests

## Implementation
📝

## Testing
📝