### PR TITLE
Fix converting NSNotification.Name to String error

### DIFF
--- a/Sources/Capable/Plugins/DifferentiateWithoutColor.swift
+++ b/Sources/Capable/Plugins/DifferentiateWithoutColor.swift
@@ -55,7 +55,7 @@ extension DifferentiateWithoutColor: ObservableFeatureProtocol {
                 notificationCenter.addObserver(
                     self,
                     selector: #selector(valueChanged),
-                    name: NSNotification.Name(rawValue: UIAccessibility.differentiateWithoutColorDidChangeNotification),
+                    name: NSNotification.Name(rawValue: UIAccessibility.differentiateWithoutColorDidChangeNotification.rawValue),
                     object: nil
                 )
             }


### PR DESCRIPTION
This is an attempt to fix the "Cannot convert value of type 'NSNotification.Name' to expected argument type 'String'" issue.

Although appending '.rawValue' resolves the error, it would probably be more elegant if that line is just:
    name: UIAccessibility.differentiateWithoutColorDidChangeNotification

## Issue information
Right now, I'm getting the following issue when I try and build Capable as a SPM dependency:
"Cannot convert value of type 'NSNotification.Name' to expected argument type 'String'".

## Goal
Try and get Capable to compile when used as SPM dependency.

## Implementation
Added .rawValue so NSNotification.Name is passed the string value.

## Testing
Code compiles after making the change.